### PR TITLE
Add major-actions-dependencies Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,5 @@ updates:
       minor-actions-dependencies:
         # Only group minor and patch updates (we want to carefully review major updates)
         update-types: [minor, patch]
+      major-actions-dependencies:
+        update-types: [major]


### PR DESCRIPTION
## Summary
- Adds a `major-actions-dependencies` group to `.github/dependabot.yml` so Dependabot raises PRs for GitHub Actions major-version bumps.

## Why
The existing `minor-actions-dependencies` group has no `patterns:`, so it implicitly matches every actions dependency. Its `update-types: [minor, patch]` filter then excludes majors from the group — but because the deps are "claimed" by that group, majors aren't re-emitted as individual PRs either. Result: action major bumps have been silently skipped.

Concrete cases we missed: `jdx/mise-action` v3→v4 (2026-03-22) and `pnpm/action-setup` v4→v5 (2026-03-17). Both releases exist solely to move the action runtime from Node 20 to Node 24, which would have cleared GitHub's deprecation warnings.

## Test plan
- [ ] Merge and wait for next weekly Dependabot run
- [ ] Confirm individual PRs appear for `jdx/mise-action` v3→v4 and `pnpm/action-setup` v4→v5

🤖 Generated with [Claude Code](https://claude.com/claude-code)