### PR TITLE
Bust stale dev spacectl tool cache before install

### DIFF
--- a/dist/index/index.js
+++ b/dist/index/index.js
@@ -33277,6 +33277,10 @@ var __webpack_exports__ = {};
 (() => {
 "use strict";
 
+;// CONCATENATED MODULE: external "node:fs/promises"
+const promises_namespaceObject = require("node:fs/promises");
+;// CONCATENATED MODULE: external "node:path"
+const external_node_path_namespaceObject = require("node:path");
 ;// CONCATENATED MODULE: external "os"
 const external_os_namespaceObject = require("os");
 ;// CONCATENATED MODULE: ./node_modules/@actions/core/lib/utils.js
@@ -36226,10 +36230,6 @@ function getIDToken(aud) {
 //# sourceMappingURL=core.js.map
 ;// CONCATENATED MODULE: external "node:fs"
 const external_node_fs_namespaceObject = require("node:fs");
-;// CONCATENATED MODULE: external "node:fs/promises"
-const promises_namespaceObject = require("node:fs/promises");
-;// CONCATENATED MODULE: external "node:path"
-const external_node_path_namespaceObject = require("node:path");
 // EXTERNAL MODULE: ./node_modules/semver/index.js
 var node_modules_semver = __nccwpck_require__(2088);
 ;// CONCATENATED MODULE: ./node_modules/@actions/tool-cache/lib/manifest.js
@@ -41610,6 +41610,8 @@ function shouldUseSymlinks() {
 
 
 
+
+
 const Input_SpacectlVersion = 'spacectl-version';
 const Input_SpacectlSystemBinary = 'spacectl-system-binary';
 const Input_GithubToken = 'github-token';
@@ -41641,12 +41643,38 @@ async function run() {
     const versionSpec = getInput(Input_SpacectlVersion) || undefined;
     const githubToken = getInput(Input_GithubToken) || undefined;
     const systemBinary = getInput(Input_SpacectlSystemBinary) || undefined;
+    if (versionSpec && versionSpec.toLowerCase() === 'dev') {
+        await bustDevToolCache();
+    }
     await install({
         version: versionSpec,
         githubToken: githubToken,
         systemBinary: systemBinary
     });
     await mount();
+}
+// Dev releases (e.g. 0.8.0-dev) share a single tag, so binaries change in place.
+// The Namespace runner's persistent tool cache would otherwise serve a stale
+// binary indefinitely.
+async function bustDevToolCache() {
+    const toolCache = process.env.RUNNER_TOOL_CACHE;
+    if (!toolCache)
+        return;
+    const spacectlDir = external_node_path_namespaceObject.join(toolCache, 'spacectl');
+    let entries;
+    try {
+        entries = await promises_namespaceObject.readdir(spacectlDir);
+    }
+    catch {
+        return;
+    }
+    for (const entry of entries) {
+        if (entry.endsWith('-dev')) {
+            const stalePath = external_node_path_namespaceObject.join(spacectlDir, entry);
+            await promises_namespaceObject.rm(stalePath, { recursive: true, force: true });
+            info(`Removed stale dev spacectl cache at ${stalePath}`);
+        }
+    }
 }
 function verifyCacheVolume() {
     const localCachePath = process.env[Env_CacheRoot];

--- a/dist/index/index.js
+++ b/dist/index/index.js
@@ -33279,6 +33279,8 @@ var __webpack_exports__ = {};
 
 ;// CONCATENATED MODULE: external "node:fs/promises"
 const promises_namespaceObject = require("node:fs/promises");
+;// CONCATENATED MODULE: external "node:os"
+const external_node_os_namespaceObject = require("node:os");
 ;// CONCATENATED MODULE: external "node:path"
 const external_node_path_namespaceObject = require("node:path");
 ;// CONCATENATED MODULE: external "os"
@@ -37030,8 +37032,6 @@ function _unique(values) {
     return Array.from(new Set(values));
 }
 //# sourceMappingURL=tool-cache.js.map
-;// CONCATENATED MODULE: external "node:os"
-const external_node_os_namespaceObject = require("node:os");
 ;// CONCATENATED MODULE: ./node_modules/@actions/github/lib/context.js
 
 
@@ -41612,6 +41612,7 @@ function shouldUseSymlinks() {
 
 
 
+
 const Input_SpacectlVersion = 'spacectl-version';
 const Input_SpacectlSystemBinary = 'spacectl-system-binary';
 const Input_GithubToken = 'github-token';
@@ -41644,7 +41645,7 @@ async function run() {
     const githubToken = getInput(Input_GithubToken) || undefined;
     const systemBinary = getInput(Input_SpacectlSystemBinary) || undefined;
     if (versionSpec && versionSpec.toLowerCase() === 'dev') {
-        await bustDevToolCache();
+        await useEphemeralToolCache();
     }
     await install({
         version: versionSpec,
@@ -41653,28 +41654,17 @@ async function run() {
     });
     await mount();
 }
-// Dev releases (e.g. 0.8.0-dev) share a single tag, so binaries change in place.
-// The Namespace runner's persistent tool cache would otherwise serve a stale
-// binary indefinitely.
-async function bustDevToolCache() {
-    const toolCache = process.env.RUNNER_TOOL_CACHE;
-    if (!toolCache)
-        return;
-    const spacectlDir = external_node_path_namespaceObject.join(toolCache, 'spacectl');
-    let entries;
-    try {
-        entries = await promises_namespaceObject.readdir(spacectlDir);
-    }
-    catch {
-        return;
-    }
-    for (const entry of entries) {
-        if (entry.endsWith('-dev')) {
-            const stalePath = external_node_path_namespaceObject.join(spacectlDir, entry);
-            await promises_namespaceObject.rm(stalePath, { recursive: true, force: true });
-            info(`Removed stale dev spacectl cache at ${stalePath}`);
-        }
-    }
+// Dev releases (e.g. 0.8.0-dev) reuse a single tag, so the binary changes in
+// place. Redirecting RUNNER_TOOL_CACHE to a per-run directory avoids serving a
+// stale binary from the runner's persistent tool cache, and also sidesteps
+// permission issues on shared /opt/hostedtoolcache/spacectl entries that can
+// leak across runners.
+async function useEphemeralToolCache() {
+    const base = process.env.RUNNER_TEMP ?? external_node_os_namespaceObject.tmpdir();
+    const ephemeral = external_node_path_namespaceObject.join(base, 'nscloud-cache-action-spacectl-toolcache');
+    await promises_namespaceObject.mkdir(ephemeral, { recursive: true });
+    process.env.RUNNER_TOOL_CACHE = ephemeral;
+    info(`Using ephemeral spacectl tool cache at ${ephemeral}`);
 }
 function verifyCacheVolume() {
     const localCachePath = process.env[Env_CacheRoot];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import * as core from '@actions/core';
 import {install as installSpacectl} from '@namespacelabs/actions-toolkit/spacectl';
@@ -48,7 +49,7 @@ async function run() {
       | 'ignore') || undefined;
 
   if (versionSpec && versionSpec.toLowerCase() === 'dev') {
-    await bustDevToolCache();
+    await useEphemeralToolCache();
   }
 
   await installSpacectl({
@@ -60,28 +61,17 @@ async function run() {
   await mount();
 }
 
-// Dev releases (e.g. 0.8.0-dev) share a single tag, so binaries change in place.
-// The Namespace runner's persistent tool cache would otherwise serve a stale
-// binary indefinitely.
-async function bustDevToolCache(): Promise<void> {
-  const toolCache = process.env.RUNNER_TOOL_CACHE;
-  if (!toolCache) return;
-
-  const spacectlDir = path.join(toolCache, 'spacectl');
-  let entries: string[];
-  try {
-    entries = await fs.readdir(spacectlDir);
-  } catch {
-    return;
-  }
-
-  for (const entry of entries) {
-    if (entry.endsWith('-dev')) {
-      const stalePath = path.join(spacectlDir, entry);
-      await fs.rm(stalePath, {recursive: true, force: true});
-      core.info(`Removed stale dev spacectl cache at ${stalePath}`);
-    }
-  }
+// Dev releases (e.g. 0.8.0-dev) reuse a single tag, so the binary changes in
+// place. Redirecting RUNNER_TOOL_CACHE to a per-run directory avoids serving a
+// stale binary from the runner's persistent tool cache, and also sidesteps
+// permission issues on shared /opt/hostedtoolcache/spacectl entries that can
+// leak across runners.
+async function useEphemeralToolCache(): Promise<void> {
+  const base = process.env.RUNNER_TEMP ?? os.tmpdir();
+  const ephemeral = path.join(base, 'nscloud-cache-action-spacectl-toolcache');
+  await fs.mkdir(ephemeral, {recursive: true});
+  process.env.RUNNER_TOOL_CACHE = ephemeral;
+  core.info(`Using ephemeral spacectl tool cache at ${ephemeral}`);
 }
 
 function verifyCacheVolume(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 import * as core from '@actions/core';
 import {install as installSpacectl} from '@namespacelabs/actions-toolkit/spacectl';
 import * as action from './action';
@@ -45,6 +47,10 @@ async function run() {
       | 'require'
       | 'ignore') || undefined;
 
+  if (versionSpec && versionSpec.toLowerCase() === 'dev') {
+    await bustDevToolCache();
+  }
+
   await installSpacectl({
     version: versionSpec,
     githubToken: githubToken,
@@ -52,6 +58,30 @@ async function run() {
   });
 
   await mount();
+}
+
+// Dev releases (e.g. 0.8.0-dev) share a single tag, so binaries change in place.
+// The Namespace runner's persistent tool cache would otherwise serve a stale
+// binary indefinitely.
+async function bustDevToolCache(): Promise<void> {
+  const toolCache = process.env.RUNNER_TOOL_CACHE;
+  if (!toolCache) return;
+
+  const spacectlDir = path.join(toolCache, 'spacectl');
+  let entries: string[];
+  try {
+    entries = await fs.readdir(spacectlDir);
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (entry.endsWith('-dev')) {
+      const stalePath = path.join(spacectlDir, entry);
+      await fs.rm(stalePath, {recursive: true, force: true});
+      core.info(`Removed stale dev spacectl cache at ${stalePath}`);
+    }
+  }
 }
 
 function verifyCacheVolume(): void {


### PR DESCRIPTION
## Summary
- Namespace runners persist `/opt/hostedtoolcache` across runs, so once a spacectl `-dev` version (e.g. `0.8.0-dev`) is cached, `@namespacelabs/actions-toolkit` keeps serving it via `tc.find()` even after upstream rebuilds the same `-dev` tag.
- This caused `spacectl-version: dev` jobs to fail with errors like `unknown mode: npm` once a new dev feature lands (see #118).
- When `spacectl-version` is `dev`, wipe any `*-dev` directories under `$RUNNER_TOOL_CACHE/spacectl/` before calling `installSpacectl`, forcing a fresh download. Immutable versions (`latest`, pinned) remain cacheable.

## Test plan
- [ ] CI passes across the `["", "dev", "latest"]` spacectl matrix.
- [ ] Re-running #118 after this merges exercises the `npm` mode successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)