### PR TITLE
fix(ci): pin astral-sh/setup-uv to a valid v7 SHA

### DIFF
--- a/.github/workflows/modes-reusable.yaml
+++ b/.github/workflows/modes-reusable.yaml
@@ -914,7 +914,7 @@ jobs:
       - *download-spacectl-binary
       - *install-spacectl-binary
       - name: Install uv
-        uses: astral-sh/setup-uv@f06b870e0a91d23284a3013acc55e6f88ab4b904 # v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: false
       - name: Setup cache


### PR DESCRIPTION
Dependabot is failing on this repo ([run](https://github.com/namespacelabs/nscloud-cache-action/actions/runs/25972272588/job/76346270777)) with:

```
error: no such commit f06b870e0a91d23284a3013acc55e6f88ab4b904
```

That SHA is pinned for `astral-sh/setup-uv` in `modes-reusable.yaml` but does not exist upstream, so Dependabot aborts the whole grouped update.

Re-pin to the SHA the `v7` tag currently resolves to (`v7.6.0`): `37802adc94f370d6bfd71619e3f0bf239e1f3b78`.