### PR TITLE
Pass spacectl binPath explicitly instead of relying on PATH

### DIFF
--- a/dist/index/index.js
+++ b/dist/index/index.js
@@ -41879,7 +41879,7 @@ async function downloadAndCache(version, platform, arch, token) {
 	info(`Cached spacectl ${version} to ${cachedPath}`);
 	return cachedPath;
 }
-async function install(options = {}) {
+async function spacectl_Ba68Nnfu_install(options = {}) {
 	const versionSpec = options.version ?? "";
 	const token = options.githubToken ?? process.env.GITHUB_TOKEN;
 	let platform;
@@ -41956,8 +41956,8 @@ const Input_Detect_Mode = 'detect';
 const Input_Cache = 'cache';
 const Input_Path = 'path';
 const Output_CacheHit = 'cache-hit';
-async function action_mount(options) {
-    const result = await spacectl_Ba68Nnfu_exec(getMountCommand(options));
+async function action_mount(options, binPath) {
+    const result = await spacectl_Ba68Nnfu_exec(getMountCommand(options), { binPath });
     return JSON.parse(result.stdout.trim());
 }
 function exportAddEnvs(addEnvs) {
@@ -42125,12 +42125,13 @@ async function run() {
     const versionSpec = getInput(Input_SpacectlVersion) || undefined;
     const githubToken = getInput(Input_GithubToken) || undefined;
     const systemBinary = getInput(Input_SpacectlSystemBinary) || undefined;
-    await install({
+    const install = await spacectl_Ba68Nnfu_install({
         version: versionSpec,
         githubToken: githubToken,
-        systemBinary: systemBinary
+        systemBinary: systemBinary,
+        addToPath: false
     });
-    await mount();
+    await mount(install.binPath);
 }
 function verifyCacheVolume() {
     const localCachePath = process.env[Env_CacheRoot];
@@ -42157,9 +42158,9 @@ See also https://namespace.so/docs/solutions/github-actions/caching
 
 Are you running in a container? Check out https://namespace.so/docs/reference/github-actions/runner-configuration#jobs-in-containers`);
 }
-async function mount() {
+async function mount(binPath) {
     const mountOptions = parseMountInputs();
-    const mount = await action_mount(mountOptions);
+    const mount = await action_mount(mountOptions, binPath);
     if (mount.input.modes.length > 0) {
         info(`Cache modes used: ${mount.input.modes.join(', ')}.`);
     }

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -210,8 +210,14 @@ describe('mount', async () => {
 
     mockExecWithPayload(payload);
 
-    const result = await action.mount(action.parseMountInputs());
+    const result = await action.mount(
+      action.parseMountInputs(),
+      '/bin/spacectl'
+    );
     expect(result).toEqual(payload);
+    expect(spacectlExec).toHaveBeenCalledWith(expect.anything(), {
+      binPath: '/bin/spacectl'
+    });
   });
 
   test('parses response with add_envs', async () => {
@@ -228,7 +234,10 @@ describe('mount', async () => {
 
     mockExecWithPayload(payload);
 
-    const result = await action.mount(action.parseMountInputs());
+    const result = await action.mount(
+      action.parseMountInputs(),
+      '/bin/spacectl'
+    );
     expect(result.output.add_envs).toEqual({NODE_PATH: '/cache/node_modules'});
   });
 
@@ -252,7 +261,10 @@ describe('mount', async () => {
 
     mockExecWithPayload(payload);
 
-    const result = await action.mount(action.parseMountInputs());
+    const result = await action.mount(
+      action.parseMountInputs(),
+      '/bin/spacectl'
+    );
     expect(result.output.removed_paths).toEqual([
       '/etc/apt/apt.conf.d/docker-clean'
     ]);
@@ -271,7 +283,10 @@ describe('mount', async () => {
 
     mockExecWithPayload(payload);
 
-    const result = await action.mount(action.parseMountInputs());
+    const result = await action.mount(
+      action.parseMountInputs(),
+      '/bin/spacectl'
+    );
     expect(result.input.paths).toEqual(['/tmp/cache']);
   });
 
@@ -287,7 +302,10 @@ describe('mount', async () => {
 
     mockExecWithPayload(payload);
 
-    const result = await action.mount(action.parseMountInputs());
+    const result = await action.mount(
+      action.parseMountInputs(),
+      '/bin/spacectl'
+    );
     expect(result.output.mounts).toBeUndefined();
   });
 
@@ -323,7 +341,10 @@ describe('mount', async () => {
 
     mockExecWithPayload(payload);
 
-    const result = await action.mount(action.parseMountInputs());
+    const result = await action.mount(
+      action.parseMountInputs(),
+      '/bin/spacectl'
+    );
     expect(result.output.mounts).toHaveLength(3);
     expect(result.output.mounts[2].cache_hit).toBe(true);
   });

--- a/src/action.ts
+++ b/src/action.ts
@@ -41,8 +41,11 @@ export interface MountResponseOutputMount {
   cache_hit: boolean;
 }
 
-export async function mount(options: MountOptions): Promise<MountResponse> {
-  const result = await spacectlExec(getMountCommand(options));
+export async function mount(
+  options: MountOptions,
+  binPath: string
+): Promise<MountResponse> {
+  const result = await spacectlExec(getMountCommand(options), {binPath});
   return JSON.parse(result.stdout.trim()) as MountResponse;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,13 +45,14 @@ async function run() {
       | 'require'
       | 'ignore') || undefined;
 
-  await installSpacectl({
+  const install = await installSpacectl({
     version: versionSpec,
     githubToken: githubToken,
-    systemBinary: systemBinary
+    systemBinary: systemBinary,
+    addToPath: false
   });
 
-  await mount();
+  await mount(install.binPath);
 }
 
 function verifyCacheVolume(): void {
@@ -85,9 +86,9 @@ Are you running in a container? Check out https://namespace.so/docs/reference/gi
   );
 }
 
-async function mount() {
+async function mount(binPath: string) {
   const mountOptions = action.parseMountInputs();
-  const mount = await action.mount(mountOptions);
+  const mount = await action.mount(mountOptions, binPath);
 
   if (mount.input.modes.length > 0) {
     core.info(`Cache modes used: ${mount.input.modes.join(', ')}.`);


### PR DESCRIPTION
Adding `spacectl` to the $PATH can be unsafe when the surrounding directory is changing. To remove those risks, we can safely use an absolute path.