### PR TITLE
Remove unused Unix-only helpers from utils

### DIFF
--- a/dist/index/index.js
+++ b/dist/index/index.js
@@ -41999,7 +41999,6 @@ function getMountCommand(options) {
 
 
 
-
 const Env_CacheRoot = 'NSC_CACHE_PATH';
 const StatePathsKey = 'paths';
 const StateMountKey = 'mount';
@@ -42013,57 +42012,6 @@ function resolveHome(filepath) {
         return path.join(home, ...pathParts.slice(1));
     }
     return filepath;
-}
-// Creates directories in path. Exercises root permissions,
-// but sets owner for created dirs to the current user.
-async function sudoMkdirP(path) {
-    const anc = ancestors(path);
-    for (const p of anc) {
-        if (fs.existsSync(p)) {
-            core.debug(`${p} already exists`);
-            continue;
-        }
-        const { exitCode, stderr } = await exec.getExecOutput('sudo', ['mkdir', p], {
-            silent: true,
-            ignoreReturnCode: true
-        });
-        if (exitCode > 0) {
-            // Sadly, the exit code is 1 and we cannot match for EEXIST in case of concurrent directory creation.
-            if (fs.existsSync(p)) {
-                core.debug(`${p} was concurrently created`);
-                continue;
-            }
-            core.info(stderr);
-            throw new Error(`'sudo mkdir ${p}' failed with exit code ${exitCode}`);
-        }
-        await chownSelf(p);
-    }
-}
-async function chownSelf(path) {
-    const uid = process.getuid();
-    const gid = process.getgid();
-    const userColonGroup = `${uid}:${gid}`;
-    await exec.exec('sudo', ['chown', userColonGroup, path]);
-}
-function ancestors(filepath) {
-    const res = [];
-    let norm = path.normalize(filepath);
-    while (norm !== '.' && norm !== '/') {
-        res.unshift(norm);
-        const next = path.dirname(norm);
-        if (next === norm)
-            break;
-        norm = next;
-    }
-    return res;
-}
-async function getCacheUtil(cachePath) {
-    const { stdout } = await exec.getExecOutput(`/bin/sh -c "du -sb ${cachePath} | cut -f1"`, [], {
-        silent: true,
-        ignoreReturnCode: true
-    });
-    const cacheUtil = Number.parseInt(stdout.trim());
-    return cacheUtil;
 }
 function ensureCacheMetadata(cachePath) {
     const namespaceFolderPath = path.join(cachePath, privateNamespaceDir);

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -31053,7 +31053,6 @@ const external_node_fs_namespaceObject = require("node:fs");
 
 
 
-
 const Env_CacheRoot = 'NSC_CACHE_PATH';
 const StatePathsKey = 'paths';
 const StateMountKey = 'mount';
@@ -31067,57 +31066,6 @@ function resolveHome(filepath) {
         return external_node_path_namespaceObject.join(home, ...pathParts.slice(1));
     }
     return filepath;
-}
-// Creates directories in path. Exercises root permissions,
-// but sets owner for created dirs to the current user.
-async function sudoMkdirP(path) {
-    const anc = ancestors(path);
-    for (const p of anc) {
-        if (fs.existsSync(p)) {
-            core.debug(`${p} already exists`);
-            continue;
-        }
-        const { exitCode, stderr } = await exec.getExecOutput('sudo', ['mkdir', p], {
-            silent: true,
-            ignoreReturnCode: true
-        });
-        if (exitCode > 0) {
-            // Sadly, the exit code is 1 and we cannot match for EEXIST in case of concurrent directory creation.
-            if (fs.existsSync(p)) {
-                core.debug(`${p} was concurrently created`);
-                continue;
-            }
-            core.info(stderr);
-            throw new Error(`'sudo mkdir ${p}' failed with exit code ${exitCode}`);
-        }
-        await chownSelf(p);
-    }
-}
-async function chownSelf(path) {
-    const uid = process.getuid();
-    const gid = process.getgid();
-    const userColonGroup = `${uid}:${gid}`;
-    await exec.exec('sudo', ['chown', userColonGroup, path]);
-}
-function ancestors(filepath) {
-    const res = [];
-    let norm = path.normalize(filepath);
-    while (norm !== '.' && norm !== '/') {
-        res.unshift(norm);
-        const next = path.dirname(norm);
-        if (next === norm)
-            break;
-        norm = next;
-    }
-    return res;
-}
-async function getCacheUtil(cachePath) {
-    const { stdout } = await exec.getExecOutput(`/bin/sh -c "du -sb ${cachePath} | cut -f1"`, [], {
-        silent: true,
-        ignoreReturnCode: true
-    });
-    const cacheUtil = Number.parseInt(stdout.trim());
-    return cacheUtil;
 }
 function ensureCacheMetadata(cachePath) {
     const namespaceFolderPath = path.join(cachePath, privateNamespaceDir);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,5 @@
 import * as path from 'node:path';
 import * as core from '@actions/core';
-import * as exec from '@actions/exec';
 import * as fs from 'node:fs';
 
 export const Env_CacheRoot = 'NSC_CACHE_PATH';
@@ -24,68 +23,6 @@ export function resolveHome(filepath: string): string {
     return path.join(home, ...pathParts.slice(1));
   }
   return filepath;
-}
-
-// Creates directories in path. Exercises root permissions,
-// but sets owner for created dirs to the current user.
-export async function sudoMkdirP(path: string) {
-  const anc = ancestors(path);
-  for (const p of anc) {
-    if (fs.existsSync(p)) {
-      core.debug(`${p} already exists`);
-      continue;
-    }
-
-    const {exitCode, stderr} = await exec.getExecOutput('sudo', ['mkdir', p], {
-      silent: true,
-      ignoreReturnCode: true
-    });
-
-    if (exitCode > 0) {
-      // Sadly, the exit code is 1 and we cannot match for EEXIST in case of concurrent directory creation.
-      if (fs.existsSync(p)) {
-        core.debug(`${p} was concurrently created`);
-        continue;
-      }
-
-      core.info(stderr);
-      throw new Error(`'sudo mkdir ${p}' failed with exit code ${exitCode}`);
-    }
-
-    await chownSelf(p);
-  }
-}
-
-export async function chownSelf(path: string) {
-  const uid = process.getuid!();
-  const gid = process.getgid!();
-  const userColonGroup = `${uid}:${gid}`;
-  await exec.exec('sudo', ['chown', userColonGroup, path]);
-}
-
-function ancestors(filepath: string) {
-  const res: string[] = [];
-  let norm = path.normalize(filepath);
-  while (norm !== '.' && norm !== '/') {
-    res.unshift(norm);
-    const next = path.dirname(norm);
-    if (next === norm) break;
-    norm = next;
-  }
-  return res;
-}
-
-export async function getCacheUtil(cachePath: string): Promise<number> {
-  const {stdout} = await exec.getExecOutput(
-    `/bin/sh -c "du -sb ${cachePath} | cut -f1"`,
-    [],
-    {
-      silent: true,
-      ignoreReturnCode: true
-    }
-  );
-  const cacheUtil = Number.parseInt(stdout.trim());
-  return cacheUtil;
 }
 
 export interface CacheMetadata {


### PR DESCRIPTION
Removes four exported helpers in `src/utils.ts` that were never called by the action runtime (`index.ts`, `post.ts`, `action.ts`):

- `sudoMkdirP` — `sudo mkdir`
- `chownSelf` — `process.getuid/getgid` + `sudo chown`
- `ancestors` — private helper only used by `sudoMkdirP`
- `getCacheUtil` — `/bin/sh -c "du -sb … | cut -f1"`

These relied on `sudo`, POSIX uid/gid, and `/bin/sh`+`du`+`cut`, none of which exist on Windows runners. They were dead code today, but a latent cross-platform trap as we add Windows support — removing them keeps the runtime path clean and OS-agnostic.

Also drops the now-unused `@actions/exec` import. (`@actions/exec` is left declared in `package.json` to avoid unrelated `package-lock.json` churn; it is not bundled by ncc.)

## Validation
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm test -- run` ✅ (21 tests)
- `npm run build` ✅ — regenerated `dist/` is exactly the 104 removed lines, no unrelated churn

No runtime behavior change: the action delegates mount/install to spacectl + actions-toolkit and never invoked these helpers.