### PR TITLE
Validate cache links on Windows runners

### DIFF
--- a/dist/index/index.js
+++ b/dist/index/index.js
@@ -42005,13 +42005,11 @@ const StateMountKey = 'mount';
 const privateNamespaceDir = '.ns';
 const metadataFileName = 'cache-metadata.json';
 function resolveHome(filepath) {
-    // Ugly, but should work
-    const home = process.env.HOME || '~';
-    const pathParts = filepath.split(path.sep);
-    if (pathParts.length > 1 && pathParts[0] === '~') {
-        return path.join(home, ...pathParts.slice(1));
+    if (!filepath.startsWith('~/') && !filepath.startsWith('~\\')) {
+        return filepath;
     }
-    return filepath;
+    const home = process.env.HOME || process.env.USERPROFILE || '~';
+    return path.join(home, filepath.slice(2));
 }
 function ensureCacheMetadata(cachePath) {
     const namespaceFolderPath = path.join(cachePath, privateNamespaceDir);
@@ -42031,10 +42029,13 @@ function writeCacheMetadata(cachePath, metadata) {
     const rawData = JSON.stringify(metadata);
     fs.writeFileSync(metadataFilePath, rawData, { mode: 0o666 });
 }
-function shouldUseSymlinks() {
-    const useSymlinks = process.env.RUNNER_OS === 'macOS';
-    core.debug(`Using symlinks: ${useSymlinks} on ${process.env.RUNNER_OS}.`);
-    return useSymlinks;
+// macOS (symlink) and Windows (junction) expose the cache via a clobberable
+// link, so the post step verifies it survived. Linux uses a robust bind mount.
+function usesLinkMount() {
+    const runnerOs = process.env.RUNNER_OS;
+    const linkMount = runnerOs === 'macOS' || runnerOs === 'Windows';
+    core.debug(`Using link mount: ${linkMount} on ${runnerOs}.`);
+    return linkMount;
 }
 
 ;// CONCATENATED MODULE: ./src/index.ts

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -31059,13 +31059,11 @@ const StateMountKey = 'mount';
 const privateNamespaceDir = '.ns';
 const metadataFileName = 'cache-metadata.json';
 function resolveHome(filepath) {
-    // Ugly, but should work
-    const home = process.env.HOME || '~';
-    const pathParts = filepath.split(external_node_path_namespaceObject.sep);
-    if (pathParts.length > 1 && pathParts[0] === '~') {
-        return external_node_path_namespaceObject.join(home, ...pathParts.slice(1));
+    if (!filepath.startsWith('~/') && !filepath.startsWith('~\\')) {
+        return filepath;
     }
-    return filepath;
+    const home = process.env.HOME || process.env.USERPROFILE || '~';
+    return external_node_path_namespaceObject.join(home, filepath.slice(2));
 }
 function ensureCacheMetadata(cachePath) {
     const namespaceFolderPath = path.join(cachePath, privateNamespaceDir);
@@ -31085,10 +31083,13 @@ function writeCacheMetadata(cachePath, metadata) {
     const rawData = JSON.stringify(metadata);
     fs.writeFileSync(metadataFilePath, rawData, { mode: 0o666 });
 }
-function shouldUseSymlinks() {
-    const useSymlinks = process.env.RUNNER_OS === 'macOS';
-    core_debug(`Using symlinks: ${useSymlinks} on ${process.env.RUNNER_OS}.`);
-    return useSymlinks;
+// macOS (symlink) and Windows (junction) expose the cache via a clobberable
+// link, so the post step verifies it survived. Linux uses a robust bind mount.
+function utils_usesLinkMount() {
+    const runnerOs = process.env.RUNNER_OS;
+    const linkMount = runnerOs === 'macOS' || runnerOs === 'Windows';
+    core_debug(`Using link mount: ${linkMount} on ${runnerOs}.`);
+    return linkMount;
 }
 
 ;// CONCATENATED MODULE: ./src/post.ts
@@ -31103,13 +31104,13 @@ async function main() {
         return;
     }
     const mount = JSON.parse(rawMount);
-    const useSymlinks = shouldUseSymlinks();
-    if (!useSymlinks) {
+    const usesLinkMount = utils_usesLinkMount();
+    if (!usesLinkMount) {
         core_debug('Using bind mounts: no risk of finding them deleted.');
     }
     let foundProblems = false;
     for (const m of mount.output.mounts ?? []) {
-        if (useSymlinks) {
+        if (usesLinkMount) {
             const expandedPath = resolveHome(m.mount_path);
             const st = external_node_fs_namespaceObject.lstatSync(expandedPath, { throwIfNoEntry: false });
             if (st == null) {
@@ -31117,8 +31118,9 @@ async function main() {
                 foundProblems = true;
                 continue;
             }
+            // isSymbolicLink() is true for both macOS symlinks and Windows junctions.
             if (!st.isSymbolicLink()) {
-                warning(`${m.mount_path}: was linked to the cache volume, but is not a symlink anymore. Did another action (e.g. checkout) overwrite it?`);
+                warning(`${m.mount_path}: was linked to the cache volume, but is not a link anymore. Did another action (e.g. checkout) overwrite it?`);
                 foundProblems = true;
                 continue;
             }

--- a/src/post.ts
+++ b/src/post.ts
@@ -14,15 +14,15 @@ async function main() {
 
   const mount = JSON.parse(rawMount) as action.MountResponse;
 
-  const useSymlinks = utils.shouldUseSymlinks();
-  if (!useSymlinks) {
+  const usesLinkMount = utils.usesLinkMount();
+  if (!usesLinkMount) {
     core.debug('Using bind mounts: no risk of finding them deleted.');
   }
 
   let foundProblems = false;
 
   for (const m of mount.output.mounts ?? []) {
-    if (useSymlinks) {
+    if (usesLinkMount) {
       const expandedPath = utils.resolveHome(m.mount_path);
       const st = fs.lstatSync(expandedPath, {throwIfNoEntry: false});
 
@@ -34,9 +34,10 @@ async function main() {
         continue;
       }
 
+      // isSymbolicLink() is true for both macOS symlinks and Windows junctions.
       if (!st.isSymbolicLink()) {
         core.warning(
-          `${m.mount_path}: was linked to the cache volume, but is not a symlink anymore. Did another action (e.g. checkout) overwrite it?`
+          `${m.mount_path}: was linked to the cache volume, but is not a link anymore. Did another action (e.g. checkout) overwrite it?`
         );
         foundProblems = true;
         continue;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,75 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import * as path from 'node:path';
+import * as utils from './utils';
+
+vi.mock('@actions/core', () => ({
+  debug: vi.fn()
+}));
+
+const ORIGINAL_ENV = {...process.env};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  process.env = {...ORIGINAL_ENV};
+});
+
+describe('usesLinkMount', () => {
+  test('true on macOS (symlink mount)', () => {
+    process.env.RUNNER_OS = 'macOS';
+    expect(utils.usesLinkMount()).toBe(true);
+  });
+
+  test('true on Windows (junction mount)', () => {
+    process.env.RUNNER_OS = 'Windows';
+    expect(utils.usesLinkMount()).toBe(true);
+  });
+
+  test('false on Linux (bind mount)', () => {
+    process.env.RUNNER_OS = 'Linux';
+    expect(utils.usesLinkMount()).toBe(false);
+  });
+
+  test('false when RUNNER_OS is unset', () => {
+    delete process.env.RUNNER_OS;
+    expect(utils.usesLinkMount()).toBe(false);
+  });
+});
+
+describe('resolveHome', () => {
+  test('expands a leading ~/ using HOME', () => {
+    process.env.HOME = '/home/runner';
+    delete process.env.USERPROFILE;
+    expect(utils.resolveHome('~/.cache/go-build')).toBe(
+      path.join('/home/runner', '.cache/go-build')
+    );
+  });
+
+  test('falls back to USERPROFILE when HOME is unset', () => {
+    delete process.env.HOME;
+    process.env.USERPROFILE = 'C:\\Users\\runneradmin';
+    expect(utils.resolveHome('~\\AppData\\Local')).toBe(
+      path.join('C:\\Users\\runneradmin', 'AppData\\Local')
+    );
+  });
+
+  test('leaves absolute paths untouched', () => {
+    process.env.HOME = '/home/runner';
+    expect(utils.resolveHome('/var/cache/apt')).toBe('/var/cache/apt');
+    expect(utils.resolveHome('C:\\Users\\runner\\AppData\\Local')).toBe(
+      'C:\\Users\\runner\\AppData\\Local'
+    );
+  });
+
+  test('does not expand a bare ~', () => {
+    process.env.HOME = '/home/runner';
+    expect(utils.resolveHome('~')).toBe('~');
+  });
+
+  test('does not expand ~ in the middle of a path', () => {
+    process.env.HOME = '/home/runner';
+    expect(utils.resolveHome('/opt/~/cache')).toBe('/opt/~/cache');
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,13 +16,11 @@ export interface CachePath {
 }
 
 export function resolveHome(filepath: string): string {
-  // Ugly, but should work
-  const home = process.env.HOME || '~';
-  const pathParts = filepath.split(path.sep);
-  if (pathParts.length > 1 && pathParts[0] === '~') {
-    return path.join(home, ...pathParts.slice(1));
+  if (!filepath.startsWith('~/') && !filepath.startsWith('~\\')) {
+    return filepath;
   }
-  return filepath;
+  const home = process.env.HOME || process.env.USERPROFILE || '~';
+  return path.join(home, filepath.slice(2));
 }
 
 export interface CacheMetadata {
@@ -59,8 +57,11 @@ export function writeCacheMetadata(cachePath: string, metadata: CacheMetadata) {
   fs.writeFileSync(metadataFilePath, rawData, {mode: 0o666});
 }
 
-export function shouldUseSymlinks() {
-  const useSymlinks = process.env.RUNNER_OS === 'macOS';
-  core.debug(`Using symlinks: ${useSymlinks} on ${process.env.RUNNER_OS}.`);
-  return useSymlinks;
+// macOS (symlink) and Windows (junction) expose the cache via a clobberable
+// link, so the post step verifies it survived. Linux uses a robust bind mount.
+export function usesLinkMount() {
+  const runnerOs = process.env.RUNNER_OS;
+  const linkMount = runnerOs === 'macOS' || runnerOs === 'Windows';
+  core.debug(`Using link mount: ${linkMount} on ${runnerOs}.`);
+  return linkMount;
 }


### PR DESCRIPTION
## Summary

Makes the post-step cache-integrity validation cover Windows, now that spacectl mounts the cache on Windows.

Per [spacectl#55](https://github.com/namespacelabs/spacectl/pull/55), `spacectl cache mount` uses a per-OS strategy:

| OS | Mechanism | Clobberable by a later step? |
|----|-----------|------------------------------|
| Linux | `mount --bind` | No (kernel mount) |
| macOS | symlink (`ln -sfn`) | Yes |
| **Windows** | **directory junction (`mklink /J`)** | **Yes** |

A junction is an NTFS reparse point — like a macOS symlink, a later action (e.g. `actions/checkout`) can delete it or replace it with a real directory, silently sending writes outside the cache. The post step already detects this on macOS via `lstat`; Node/libuv reports a junction as a symbolic link (`isSymbolicLink()` returns `true`), so the same check works on Windows once we opt it in.

## Changes
- **`usesLinkMount()`** (renamed from `shouldUseSymlinks`): returns `true` on macOS **and** Windows. The real distinction is link-based mount (fragile → verify) vs bind mount (robust → skip); the old name implied symlinks specifically and hid the junction case. Kept as a single function because the post-step validation is identical for symlinks and junctions — splitting into two would just OR them around identical code.
- `resolveHome()`: handle Windows path separators and fall back to `USERPROFILE`, since it now runs against Windows mount paths.
- post-step wording: `symlink` → `link` so the warning reads correctly for junctions.
- Added unit tests (`src/utils.test.ts`) for `usesLinkMount` and `resolveHome`.

## Validation
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm test -- run` ✅ (30 tests)
- `npm run build` ✅ — regenerated `dist/` diff is exactly the intended changes, no churn

## Notes
- Depends on spacectl#55 and the runner-side cache volume being wired on Windows; until then the action errors early (no `NSC_CACHE_PATH`) on Windows, unchanged.
- No behavior change on Linux/macOS.